### PR TITLE
Adding org-wide templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/L5_requirement.yml
+++ b/.github/ISSUE_TEMPLATE/L5_requirement.yml
@@ -1,0 +1,45 @@
+name: L5 Requirement
+description: Create an L5 requirement
+title: "[L5] "
+labels: ["Requirement: Level 5"]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      L5 requirements, which should be flowed down from L4 requirements.
+      These requirements are typically related to the implementation of
+      the L4 requirements, and there may additionally be subtasks that
+      can be created to complete the L5 requirement.
+
+- type: textarea
+  attributes:
+    label: "Summary of the L5 requirement"
+    description: >
+      A short summary of the L5 requirement.
+    placeholder: |
+      **Summary**
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Parent requirement"
+    description: >
+      The L4 requirement that this L5 requirement is related to.
+    placeholder: |
+      **Parent requirement**
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Tasks"
+    description: >
+      Tasks to complete this L5 requirement.
+    placeholder: |
+      **Tasks**
+      - [ ] Task 1 (can be issue # or PR #)
+      - [ ] Task 2 (can be issue # or PR #)
+  validations:
+    required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+# Change Summary
+
+## Overview
+<!--Add a list or paragraph giving an overview of your changes-->
+
+## New Dependencies
+<!--List any new dependencies introduced by these changes-->
+
+## New Files
+<!--List each new file and add bullets to describe the purpose/function of the new file.
+This should be high level, but enough detail for the reviewer to understand what purpose(s) the
+code in the file is serving-->
+- new file 1
+   - description of new file 1's purpose
+
+## Deleted Files
+<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
+- deleted file 1
+   - explanation for why file was deleted
+
+## Updated Files
+<!--List each updated file and add bullets to describe the purpose/function of the updates.
+This should be high level, but enough detail for the reviewer to understand what purpose(s) the
+updated code in the file is serving-->
+- updated file 1
+   - description of change 1 in file 1
+   - description of change 2 in file 2
+- updated file 2
+   - descipriton of change 1 in file 2
+
+## Testing
+<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,102 @@
+# IMAP Science Operations Center Code of Conduct
+
+## Introduction
+
+This code of conduct applies to all spaces related to the `imap_processing`
+project, including all public and private mailing lists, repositories, issue
+trackers, wikis, and any other communication channel used by our community.
+
+This code of conduct should be honored by everyone who participates in the
+project formally or informally, or claims any affiliation with the project, in
+any project-related activities and especially when representing the project, in
+any role.
+
+This code is not exhaustive or complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. Please try to
+follow this code in spirit as much as in letter, to create a friendly and
+productive environment that enriches the surrounding community.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+imap-sdc@lists.lasp.colorado.edu.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Copied some of the contents over from imap_processing. I also added a new L5 issue template. If you go to view the file directly in the PR it should render how you would see it when opening an issue.