### PR TITLE
Add README to organization

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,64 @@
+<div id="header" align="center">
+    <a href="https://imap.princeton.edu/" target="_blank">
+        <img src="https://imap.princeton.edu/sites/g/files/toruqf1601/files/imap-mark-hor-multicolor-dark.png" style="display: block; width: 50%;"/>
+    </a>
+    <h1>Welcome to the IMAP Science Operations Center<br>GitHub Organization</h1>
+    <p>
+        This GitHub organization contains repositories used to support the IMAP Science Operations Center (SOC). The IMAP SOC, located at the Laboratory for Atmospheric and Space Physics (LASP),
+        is responsible for all aspects of instrument operations, including planning, commanding, heath and status monitoring, anomaly response, and sustaining engineering for the instruments.
+        The SOC also handles science data processing (including data calibration, validation, and preliminary analysis), distribution, archiving, and maintaining the IMAP data management plan.
+    </p>
+</div>
+
+<br>
+
+### Repositories
+
+| Name | Description | 
+|---|---| 
+| [imap_processing](https://github.com/IMAP-Science-Operations-Center/imap_processing) | Software for performing L0->L3 data processing | 
+| [sds-data-manager](https://github.com/IMAP-Science-Operations-Center/sds-data-manager) | Software for building and configuring AWS architecture to support data processing | 
+| [sds-access-lib](https://github.com/IMAP-Science-Operations-Center/sds-access-lib) | Contains a simple script that allows a user to upload, query, and download data from the IMAP Science Data Center | 
+| [imap_python_processing_example](https://github.com/IMAP-Science-Operations-Center/imap_python_processing_example) | Contains an example for containerizing algorithm software written in Python | 
+| [imap_matlab_processing_example](https://github.com/IMAP-Science-Operations-Center/imap_matlab_processing_example) | Contains an example for containerizing algorithm software written in MATLAB | 
+| [.github](https://github.com/IMAP-Science-Operations-Center/.github) | Contains workflows, templates, and other files that are common to all organization repositories |
+
+<br>
+
+### Languages, Tools, and Libraries
+
+The following languages, tools, and libraries are used to support the work that we do!
+
+[<img src="https://avatars.githubusercontent.com/u/2232217?s=200&v=4" alt="aws" width="60" height="60"/>](https://aws.amazon.com/)
+[<img src="https://res.cloudinary.com/practicaldev/image/fetch/s--pvYK2BAd--/c_imagga_scale,f_auto,fl_progressive,h_1080,q_auto,w_1080/https://thepracticaldev.s3.amazonaws.com/i/061ye176kky7igpkcrhk.png" alt="black" width="60" height="60"/>](https://pypi.org/project/black/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/codecov/codecov-plain.svg" alt="codecov" width="60" height="60"/>](https://about.codecov.io/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/confluence/confluence-original.svg" alt="confluence" width="60" height="60"/>](https://www.atlassian.com/software/confluence)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original-wordmark.svg" alt="docker" width="60" height="60"/>](https://www.docker.com)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original-wordmark.svg" alt="git" width="60" height="60"/>](https://git-scm.com)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" alt="github" width="60" height="60"/>](https://github.com/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-original.svg" alt="linux" width="60" height="60"/>](https://www.linux.org/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/matlab/matlab-original.svg" alt="matlab" width="60" height="60"/>](https://www.mathworks.com/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/numpy/numpy-original.svg" alt="numpy" width="60" height="60"/>](https://numpy.org/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/pandas/pandas-original-wordmark.svg" alt="pandas" width="60" height="60"/>](https://pandas.pydata.org)
+[<img src="https://python-poetry.org/images/logo-origami.svg" alt="poetry" width="60" height="60"/>](https://python-poetry.org/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postgresql/postgresql-original-wordmark.svg" alt="postgresql" width="60" height="60"/>](https://www.postgresql.org/)
+[<img src="https://pre-commit.com/logo.svg" alt="precommit" width="60" height="60"/>](https://pre-commit.com/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original-wordmark.svg" alt="python" width="60" height="60"/>](https://www.python.org)
+[<img src="https://pypi.org/static/images/logo-large.9f732b5f.svg" alt="pypi" width="60" height="60"/>](https://pypi.org/)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/pytest/pytest-original-wordmark.svg" alt="pytest" width="60" height="60"/>](https://docs.pytest.org/)
+[<img src="https://brand-guidelines.readthedocs.org/_images/logo-wordmark-vertical-compact-dark.png" alt="readthedocs" width="60" height="60"/>](https://about.readthedocs.com)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/slack/slack-original.svg" alt="slack" width="60" height="60"/>](https://slack.com/)
+[<img src="https://space-packet-parser.readthedocs.io/en/latest/_static/logo-no-background.png" alt="space-packet-parser" width="60" height="60"/>](https://pypi.org/project/space-packet-parser/)
+[<img src="https://gitlab.inria.fr/uploads/-/system/project/avatar/42214/sphinxdoc.png" alt="sphinx" width="60" height="60"/>](https://www.sphinx-doc.org)
+[<img src="https://www2.jpl.nasa.gov/iae/highlights/yr-end99/SPICE/NaifLogoColor_shdw.jpg" alt="spice" width="60" height="60"/>](https://naif.jpl.nasa.gov/naif/toolkit.html)
+[<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/sqlalchemy/sqlalchemy-original-wordmark.svg" alt="sqlalchemy" width="60" height="60"/>](https://www.sqlalchemy.org/)
+[<img src="https://pydata.org/wp-content/uploads/2018/09/xarray-logo-square.png" alt="xarray" width="60" height="60"/>](https://docs.xarray.dev)
+
+
+### Useful Links
+
+<ul>
+  <li>[IMAP Website](https://imap.princeton.edu/)</li>
+  <li>[Official Software Documentation](https://imap-processing.readthedocs.io/en/latest/)/li>
+  <li>[Internal IMAP Documentation](https://lasp.colorado.edu/galaxy/display/IMAP/)</li>
+</ul>

--- a/profile/README.md
+++ b/profile/README.md
@@ -58,7 +58,7 @@ The following languages, tools, and libraries are used to support the work that 
 ### Useful Links
 
 <ul>
-  <li>[IMAP Website](https://imap.princeton.edu/)</li>
-  <li>[Official Software Documentation](https://imap-processing.readthedocs.io/en/latest/)/li>
-  <li>[Internal IMAP Documentation](https://lasp.colorado.edu/galaxy/display/IMAP/)</li>
+  <li><a href="https://imap.princeton.edu/">IMAP website</a></li>
+  <li><a href="https://imap-processing.readthedocs.io/en/latest/">Official Software Documentation</a></li>
+  <li><a href="https://lasp.colorado.edu/galaxy/display/IMAP/">Internal IMAP Documentation</a></li>
 </ul>

--- a/profile/README.md
+++ b/profile/README.md
@@ -25,6 +25,16 @@
 
 <br>
 
+### Useful Links
+
+<ul>
+  <li><a href="https://imap.princeton.edu/">IMAP website</a></li>
+  <li><a href="https://imap-processing.readthedocs.io/en/latest/">Official Software Documentation</a></li>
+  <li><a href="https://lasp.colorado.edu/galaxy/display/IMAP/">Internal IMAP Documentation</a></li>
+</ul>
+
+<br>
+
 ### Languages, Tools, and Libraries
 
 The following languages, tools, and libraries are used to support the work that we do!
@@ -53,12 +63,3 @@ The following languages, tools, and libraries are used to support the work that 
 [<img src="https://www2.jpl.nasa.gov/iae/highlights/yr-end99/SPICE/NaifLogoColor_shdw.jpg" alt="spice" width="60" height="60"/>](https://naif.jpl.nasa.gov/naif/toolkit.html)
 [<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/sqlalchemy/sqlalchemy-original-wordmark.svg" alt="sqlalchemy" width="60" height="60"/>](https://www.sqlalchemy.org/)
 [<img src="https://pydata.org/wp-content/uploads/2018/09/xarray-logo-square.png" alt="xarray" width="60" height="60"/>](https://docs.xarray.dev)
-
-
-### Useful Links
-
-<ul>
-  <li><a href="https://imap.princeton.edu/">IMAP website</a></li>
-  <li><a href="https://imap-processing.readthedocs.io/en/latest/">Official Software Documentation</a></li>
-  <li><a href="https://lasp.colorado.edu/galaxy/display/IMAP/">Internal IMAP Documentation</a></li>
-</ul>


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds a `README.md` file to the IMAP-Science-Operations-Center github organization, so that users who land on the organization-level page can see useful information instead of the GitHub default

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- `README.md`
   - The new README file
