### PR TITLE
Added link to new imap-sdc-website repo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,6 +20,7 @@
 | [imap_L3_processing](https://github.com/IMAP-Science-Operations-Center/imap_L3_processing) | Software for performing L3 data processing |
 | [sds-data-manager](https://github.com/IMAP-Science-Operations-Center/sds-data-manager) | Software for building and configuring AWS architecture to support data processing | 
 | [imap-data-access](https://github.com/IMAP-Science-Operations-Center/imap-data-access) | Package and command line utility for users to download, query, and upload data from the IMAP Science Data Center | 
+| [imap-sdc-website](https://github.com/IMAP-Science-Operations-Center/imap-sdc-website) | Materials for the IMAP SDC website | 
 | [ialirt-data-access](https://github.com/IMAP-Science-Operations-Center/ialirt-data-access) | Package and command line utility for users to download and query data from I-ALiRT | 
 | [SAMMI](https://github.com/swxsoc/sammi/) | Contains tools for managing CDF metadata, created as a collaboration between SWxSOC and IMAP SDC |
 | [imap_python_processing_example](https://github.com/IMAP-Science-Operations-Center/imap_python_processing_example) | Contains an example for containerizing algorithm software written in Python | 


### PR DESCRIPTION
This PR adds a link to the new `imap-sdc-website` repo, which houses materials used for the SDC website.