### PR TITLE
Fixed broken link to IMAP image

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 <div id="header" align="center">
     <a href="https://imap.princeton.edu/" target="_blank">
-        <img src="https://imap.princeton.edu/sites/g/files/toruqf1601/files/imap-mark-hor-multicolor-dark.png" width="50%"/>
+        <img src="https://imap.princeton.edu/sites/g/files/toruqf7171/files/styles/freeform_750w/public/2024-06/IMAP%20Spacecraft%20Left%20View.png?itok=CJOugUFe" width="50%"/>
     </a>
     <h1>Welcome to the IMAP Science Operations Center<br>GitHub Organization</h1>
     <p>


### PR DESCRIPTION
This PR fixes a broken link to the IMAP image used in the GitHub organization README